### PR TITLE
Return 401 for unauthorized indicator GET

### DIFF
--- a/threatnote/api.py
+++ b/threatnote/api.py
@@ -115,7 +115,7 @@ def api_indicator_get(indicator_id):
                 indicator_dict.pop('_sa_instance_state')
             else:
                 indicator_dict={}
-        return jsonify(indicator_dict)
+            return jsonify(indicator_dict)
 
         resp = jsonify({'message' : 'unauthorized'})
         resp.status_code = 401


### PR DESCRIPTION
Move the return of `indicator_dict` up one level to be included in the conditional. This allows 401 Unauthorized to be properly returned to the requestor, rather than 503 Service Unavailable.